### PR TITLE
Add default for `Platform=AnyCPU`

### DIFF
--- a/Editor/FSharpProjectGenerator.cs
+++ b/Editor/FSharpProjectGenerator.cs
@@ -28,6 +28,7 @@ namespace Gilzoide.FSharp.Editor
             defaultProperties.AddElement("Configuration", "Condition", " '$(Configuration)' == '' ", "Debug");
             defaultProperties.AddElement("Platforms", "Editor;Player");
             defaultProperties.AddElement("Platform", "Condition", " '$(Platform)' == '' ", "Editor");
+            defaultProperties.AddElement("Platform", "Condition", " '$(Platform)' == 'AnyCPU' ", "Editor");
             defaultProperties.AddElement("AssemblyName", AssemblyName);
             defaultProperties.AddElement("OutputType", "Library");
             defaultProperties.AddElement("OutputPath", OutputDir);


### PR DESCRIPTION
Resolves (at least temporarily) #13

Not all editors may respect the sln `Platform` switch. The default in .NET is generally `AnyCPU`. As of time of writing, this fixes package import IntelliSense in Ionide. 